### PR TITLE
Cube spin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## v0.2.0
+### New Features
+- Added spin flag for allowing cubes have spin and density output
 ## v0.1.1
 ### Bug Fixes
 - Volume weighting logic error ([issue: #5](https://github.com/kerrigoon/bader-rs/issues/5))

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -386,8 +386,10 @@ mod tests {
     #[test]
     fn argument_spin() {
         let app = ClapApp::App.get();
-        let matches =
-            app.get_matches_from(vec!["bader", "density.cube", "-s", "spin.cube"]);
+        let matches = app.get_matches_from(vec!["bader",
+                                                "density.cube",
+                                                "-s",
+                                                "spin.cube"]);
         let args = Args::new(matches);
         assert_eq!(args.spin, Some(String::from("spin.cube")))
     }

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -91,6 +91,16 @@ to be infered from the filename."))
 "A reference charge to do the partitioning upon. Two files can be passed
 by using multiple flags (bader CHGCAR -r AECCAR0 -r AECCAR2). If two files are
 passed they are summed together."))
+            .arg(Arg::new("spin")
+                .short('s')
+                .long("spin")
+                .number_of_values(1)
+                .about("File containing spin density.")
+                .long_about(
+"A path to the spin density associated with the original file. This is primarily
+for cube files as if spin density exists in a CHGCAR it will be read automatically.
+If using with VASP outputs then the files for charge and spin density must only
+contain a single density (ie. the original file has been split)."))
             .arg(Arg::new("all electron")
                 .short('a')
                 .long("aec")
@@ -125,6 +135,7 @@ pub struct Args {
     pub method: Method,
     pub weight: Weight,
     pub reference: Reference,
+    pub spin: Option<String>,
     pub threads: usize,
     pub vacuum_tolerance: Option<f64>,
     pub zyx_format: bool,
@@ -217,12 +228,17 @@ impl Args {
             1 => Reference::One(String::from(references[0])),
             _ => Reference::None,
         };
+        let spin = match arguments.value_of("spin") {
+            Some(x) => Some(String::from(x)),
+            None => None,
+        };
         Self { file,
                read,
                method,
                weight,
                reference,
                threads,
+               spin,
                vacuum_tolerance,
                zyx_format }
     }
@@ -365,6 +381,15 @@ mod tests {
         let app = ClapApp::App.get();
         let _ = app.try_get_matches_from(vec!["bader", "CHGCAR", "-t", "basp"])
                    .unwrap_or_else(|e| panic!("An error occurs: {}", e));
+    }
+
+    #[test]
+    fn argument_spin() {
+        let app = ClapApp::App.get();
+        let matches =
+            app.get_matches_from(vec!["bader", "density.cube", "-s", "spin.cube"]);
+        let args = Args::new(matches);
+        assert_eq!(args.spin, Some(String::from("spin.cube")))
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,11 +23,11 @@ fn main() {
              env!("CARGO_PKG_VERSION"));
     // read the input files into a densities vector and a Density struct
     let read_function: ReadFunction = args.read;
-    let (voxel_origin, grid, atoms, mut densities) = match read_function(args.file.clone())
-    {
-        Ok(r) => r,
-        Err(e) => panic!("{}", e),
-    };
+    let (voxel_origin, grid, atoms, mut densities) =
+        match read_function(args.file.clone()) {
+            Ok(r) => r,
+            Err(e) => panic!("{}", e),
+        };
     if let Some(x) = args.spin {
         match densities.len() {
             1 => {
@@ -51,7 +51,8 @@ fn main() {
                 Ok(r) => r,
                 Err(e) => panic!("{}", e),
             };
-            assert_eq!(g, grid, "Error: Reference density has different grid size.");
+            assert_eq!(g, grid,
+                       "Error: Reference density has different grid size.");
             densities
         }
         Reference::Two(f1, f2) => {
@@ -59,13 +60,15 @@ fn main() {
                 Ok(r) => r,
                 Err(e) => panic!("{}", e),
             };
-            assert_eq!(g, grid, "Error: Reference density has different grid size.");
+            assert_eq!(g, grid,
+                       "Error: Reference density has different grid size.");
             let (_, g2, _, densities2) = match read_function(f2) {
                 Ok(r) => r,
                 Err(e) => panic!("{}", e),
             };
 
-            assert_eq!(g2, grid, "Error: Reference density has different grid size.");
+            assert_eq!(g2, grid,
+                       "Error: Reference density has different grid size.");
             let d = densities[0].par_iter()
                                 .zip(&densities2[0])
                                 .map(|(a, b)| a + b)

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ fn main() {
              env!("CARGO_PKG_VERSION"));
     // read the input files into a densities vector and a Density struct
     let read_function: ReadFunction = args.read;
-    let (voxel_origin, grid, atoms, mut densities) = match read_function(args.file)
+    let (voxel_origin, grid, atoms, mut densities) = match read_function(args.file.clone())
     {
         Ok(r) => r,
         Err(e) => panic!("{}", e),
@@ -31,16 +31,17 @@ fn main() {
     if let Some(x) = args.spin {
         match densities.len() {
             1 => {
-                let (_, _, _, d) = match read_function(x) {
+                let (_, g, _, d) = match read_function(x.clone()) {
                     Ok(r) => r,
                     Err(e) => panic!("{}", e),
                 };
                 if 1 != d.len() {
-                    panic!("Number of densities in original file is not 1. Ambiguous how to handle spin density when file contains {} densities.", d.len());
+                    panic!("Number of densities in original file is not 1. Ambiguous how to handle spin density when {} contains {} densities.", x, d.len());
                 }
+                assert_eq!(g, grid, "Error: Spin density has different grid size.");
                 densities.push(d[0].clone());
             }
-            x => panic!("Number of densities in original file is not 1. Ambiguous how to handle new spin when currently have {} spin densities.", x -1),
+            x => panic!("Number of densities in original file is not 1. Ambiguous how to handle new spin when {} already has {} spin densities.", args.file, x -1),
         }
     }
     let reference_d = match args.reference.clone() {
@@ -50,7 +51,7 @@ fn main() {
                 Ok(r) => r,
                 Err(e) => panic!("{}", e),
             };
-            assert_eq!(g, grid);
+            assert_eq!(g, grid, "Error: Reference density has different grid size.");
             densities
         }
         Reference::Two(f1, f2) => {
@@ -58,13 +59,13 @@ fn main() {
                 Ok(r) => r,
                 Err(e) => panic!("{}", e),
             };
-            assert_eq!(g, grid);
+            assert_eq!(g, grid, "Error: Reference density has different grid size.");
             let (_, g2, _, densities2) = match read_function(f2) {
                 Ok(r) => r,
                 Err(e) => panic!("{}", e),
             };
 
-            assert_eq!(g, g2);
+            assert_eq!(g2, grid, "Error: Reference density has different grid size.");
             let d = densities[0].par_iter()
                                 .zip(&densities2[0])
                                 .map(|(a, b)| a + b)

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,11 +23,26 @@ fn main() {
              env!("CARGO_PKG_VERSION"));
     // read the input files into a densities vector and a Density struct
     let read_function: ReadFunction = args.read;
-    let (voxel_origin, grid, atoms, densities) = match read_function(args.file)
+    let (voxel_origin, grid, atoms, mut densities) = match read_function(args.file)
     {
         Ok(r) => r,
         Err(e) => panic!("{}", e),
     };
+    if let Some(x) = args.spin {
+        match densities.len() {
+            1 => {
+                let (_, _, _, d) = match read_function(x) {
+                    Ok(r) => r,
+                    Err(e) => panic!("{}", e),
+                };
+                if 1 != d.len() {
+                    panic!("Number of densities in original file is not 1. Ambiguous how to handle spin density when file contains {} densities.", d.len());
+                }
+                densities.push(d[0].clone());
+            }
+            x => panic!("Number of densities in original file is not 1. Ambiguous how to handle new spin when currently have {} spin densities.", x -1),
+        }
+    }
     let reference_d = match args.reference.clone() {
         Reference::None => vec![],
         Reference::One(f) => {


### PR DESCRIPTION
Adds -s, --spin flag for manually passing a spin density for a file that doesn't contain one. This closes #10 